### PR TITLE
feat(pkgs): onboard neovim; integrate flake-compat

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,21 @@
 {
   "nodes": {
     "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -195,7 +210,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_3",
@@ -217,6 +232,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-fast-build": "nix-fast-build",
         "nixpkgs": "nixpkgs_2",

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     nix-fast-build.url = "github:Mic92/nix-fast-build";
+    flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs = { nixpkgs, flake-utils, ... }@inputs: with inputs;
@@ -31,6 +32,8 @@
           nix-fast-build = inputs.nix-fast-build.packages.${system}.default;
           glider = pkgs.callPackage ./pkgs/glider { };
           qutebrowser_nightly = pkgs.qt6Packages.callPackage ./pkgs/qutebrowser { };
+          # neovim_nightly = pkgs.callPackage ./pkgs/neovim { inherit sharedLib; };
+          neovim_nightly = pkgs.callPackage ./pkgs/neovim { };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
     flake-utils.lib.eachSystem supportedSystems (system:
       let
         pkgs = (import nixpkgs) { inherit system; config.allowUnfree = true; };
+        # lib = nixpkgs.lib;
+        # sharedLib = (import ./lib { inherit lib; });
         genChecks = system: (pre-commit-hooks.lib.${system}.run {
           src = ./.;
           hooks = {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
     flake-utils.lib.eachSystem supportedSystems (system:
       let
         pkgs = (import nixpkgs) { inherit system; config.allowUnfree = true; };
-        inherit (import ./lib { inherit (nixpkgs) lib; }) sharedLib;
+        inherit (nixpkgs) lib;
+        inherit (import ./lib { inherit lib; }) sharedLib;
+        # function to generate pre-commit-checks
         genChecks = system: (pre-commit-hooks.lib.${system}.run {
           src = ./.;
           hooks = {
@@ -25,15 +27,27 @@
             deadnix.enable = true; # linter
           };
         });
+        # function to generate package as output
+        genPkgs = { packages, qtPackages }: (
+          # (lib.attrsets.mergeAttrsList): merge attribute sets, expect input as a list
+          lib.attrsets.mergeAttrsList (
+            # (map): instantiate package from input list
+            (map (package: { "${package}_nightly" = pkgs.callPackage ./pkgs/${package} { inherit sharedLib; }; }) packages) ++
+            (map (package: { "${package}_nightly" = pkgs.qt6Packages.callPackage ./pkgs/${package} { inherit sharedLib; }; }) qtPackages)
+          ));
       in
       {
         # checks
         checks.pre-commit-check = genChecks system;
-        packages = {
-          nix-fast-build = inputs.nix-fast-build.packages.${system}.default;
-          glider = pkgs.callPackage ./pkgs/glider { };
-          qutebrowser_nightly = pkgs.qt6Packages.callPackage ./pkgs/qutebrowser { };
-          neovim_nightly = pkgs.callPackage ./pkgs/neovim { inherit sharedLib; };
-        };
+        packages = { nix-fast-build = inputs.nix-fast-build.packages.${system}.default; } //
+          genPkgs {
+            packages = [
+              "glider"
+              "neovim"
+            ];
+            qtPackages = [
+              "qutebrowser"
+            ];
+          };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,7 @@
     flake-utils.lib.eachSystem supportedSystems (system:
       let
         pkgs = (import nixpkgs) { inherit system; config.allowUnfree = true; };
-        # lib = nixpkgs.lib;
-        # sharedLib = (import ./lib { inherit lib; });
+        inherit (import ./lib { inherit (nixpkgs) lib; }) sharedLib;
         genChecks = system: (pre-commit-hooks.lib.${system}.run {
           src = ./.;
           hooks = {
@@ -34,8 +33,7 @@
           nix-fast-build = inputs.nix-fast-build.packages.${system}.default;
           glider = pkgs.callPackage ./pkgs/glider { };
           qutebrowser_nightly = pkgs.qt6Packages.callPackage ./pkgs/qutebrowser { };
-          # neovim_nightly = pkgs.callPackage ./pkgs/neovim { inherit sharedLib; };
-          neovim_nightly = pkgs.callPackage ./pkgs/neovim { };
+          neovim_nightly = pkgs.callPackage ./pkgs/neovim { inherit sharedLib; };
         };
       });
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+with builtins;
+{
+  sharedLib = {
+    # (lib.path.append): Given a directory, return a flattened list of all files within it recursively.
+    relativeToRoot = lib.path.append ../.;
+    # Scan a given directory and look for default.nix; import modules recursively
+    scanPaths = path:
+      map
+        (f: (path + "/${f}"))
+        (attrNames
+          (lib.attrsets.filterAttrs
+            (
+              _path: _type:
+                (_type == "directory") # include directories
+            )
+            (readDir path)));
+    # inherit flake-compat
+    inherit (import ./flake-compat.nix { }) legacyGetFlake;
+  };
+}

--- a/lib/flake-compat.nix
+++ b/lib/flake-compat.nix
@@ -1,0 +1,15 @@
+_:
+
+{
+  legacyGetFlake = src:
+    (import
+      (
+        let lock = builtins.fromJSON (builtins.readFile ../flake.lock); in
+        fetchTarball {
+          url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+          sha256 = lock.nodes.flake-compat.locked.narHash;
+        }
+      )
+      src
+    ).defaultNix;
+}

--- a/pkgs/glider/default.nix
+++ b/pkgs/glider/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, ...
 }:
 
 let

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, fetchFromGitHub
+  # , sharedLib
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "neovim";
+  src = ((import ../../lib/flake-compat.nix { }).legacyGetFlake
+    # src = (sharedLib.legacyGetFlake
+    {
+      src = fetchFromGitHub
+        {
+          owner = finalAttrs.name;
+          repo = finalAttrs.name;
+          rev = "ed910604ca677c897f003d00832dc6a1cb3ac65d";
+          hash = "sha256-+vfgzQFEPenQmhRl3aQ39KiU+92GVhO/4i05MyUQBOU=";
+        } + "/contrib";
+    }
+  ).packages.x86_64-linux.neovim;
+
+  installPhase = ''
+    install -D $src/bin/${finalAttrs.name} $out/bin/${finalAttrs.name}
+  '';
+})

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -1,11 +1,22 @@
 { stdenv
 , fetchFromGitHub
 , sharedLib
+, lib
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  name = "neovim";
-  version = "unstable-2024-03-24-ed91060";
+  pname = "nvim";
+  version = "unstable-2024-03-24-unwrapped";
+
+  meta = with lib; {
+    description = "Vim-fork focused on extensibility and usability";
+    homepage = "https://neovim.io/";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    mainProgram = pname;
+    maintainers = with maintainers; [ kev ];
+  };
+
   src = (sharedLib.legacyGetFlake
     {
       src = fetchFromGitHub

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -1,12 +1,11 @@
 { stdenv
 , fetchFromGitHub
-  # , sharedLib
+, sharedLib
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   name = "neovim";
-  src = ((import ../../lib/flake-compat.nix { }).legacyGetFlake
-    # src = (sharedLib.legacyGetFlake
+  src = (sharedLib.legacyGetFlake
     {
       src = fetchFromGitHub
         {

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , sharedLib
 , lib
+, ...
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -5,19 +5,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   name = "neovim";
+  version = "unstable-2024-03-24-ed91060";
   src = (sharedLib.legacyGetFlake
     {
       src = fetchFromGitHub
         {
-          owner = finalAttrs.name;
-          repo = finalAttrs.name;
-          rev = "ed910604ca677c897f003d00832dc6a1cb3ac65d";
-          hash = "sha256-+vfgzQFEPenQmhRl3aQ39KiU+92GVhO/4i05MyUQBOU=";
-        } + "/contrib";
+          owner = "nix-community";
+          repo = "neovim-nightly-overlay";
+          rev = "dc1d09c95137ce5b6889f4266ea7301d2af071f1";
+          hash = "sha256-+RQ20E5N6bQcZtSuwIx+4ELFwbfMOZ7W7tgrU9vxdA8=";
+        };
     }
   ).packages.x86_64-linux.neovim;
 
   installPhase = ''
-    install -D $src/bin/${finalAttrs.name} $out/bin/${finalAttrs.name}
+    cp -r . $out/
   '';
 })

--- a/pkgs/qutebrowser/default.nix
+++ b/pkgs/qutebrowser/default.nix
@@ -144,6 +144,6 @@ python3.pkgs.buildPythonPackage {
     license = licenses.gpl3Plus;
     mainProgram = "qutebrowser";
     platforms = if enableWideVine then [ "x86_64-linux" ] else qtwebengine.meta.platforms;
-    maintainers = with maintainers; [ jagajaga rnhmjoj ebzzry dotlambda nrdxp ];
+    maintainers = with maintainers; [ kev ];
   };
 }

--- a/pkgs/qutebrowser/default.nix
+++ b/pkgs/qutebrowser/default.nix
@@ -21,6 +21,7 @@
   # can cause issues on some graphics chips
 , enableVulkan ? false
 , vulkan-loader
+, ...
 }:
 
 let


### PR DESCRIPTION
## Summary

As the title suggests. For `neovim_nightly`, use [nix-community/neovim-nightly-overlay] as upstream as it offers binary cache.

## Changelogs

- feat: integrate flake-compact caller func
- feat(flake): add inputs.flake-compat
- feat(pkgs): add neovim
- patch(neovim): call getLegacyFlake from sharedLib
- patch(pkgs/neovim): use nix-community/neovim-nightly-overlay as upstream
- feat(pkgs/neovim): add meta attr
- refactor(flake): use genPkgs to export output.packages

## Results

just build neovim_nightly

```console
⯁ pilots git:(neovim_nightly) ❯❯❯ tree result/bin/
result/bin/
└── nvim

1 directory, 1 file
⯁ pilots git:(neovim_nightly) ❯❯❯ ./result/bin/nvim --version
NVIM v0.10.0-dev-d3e5160
Build type: Release
LuaJIT 2.1.1693350652
Run "nvim -V1 -v" for more info
```

just show

```console
⯁ pilots git:(neovim_nightly) ❯❯❯ just show
git+file:///home/kev/Workspace/personal/pilots?ref=refs/heads/neovim_nightly&rev=db476315eb7446ec3c3e4934d19e245f54e75855
├───checks
│   ├───aarch64-linux
│   │   └───pre-commit-check omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───pre-commit-check: derivation 'pre-commit-run'
└───packages
    ├───aarch64-linux
    │   ├───glider_nightly omitted (use '--all-systems' to show)
    │   ├───neovim_nightly omitted (use '--all-systems' to show)
    │   ├───nix-fast-build omitted (use '--all-systems' to show)
    │   └───qutebrowser_nightly omitted (use '--all-systems' to show)
    └───x86_64-linux
        ├───glider_nightly: package 'glider-unstable-2024-01-29-6d2b1e9'
        ├───neovim_nightly: package 'nvim-unstable-2024-03-24-unwrapped'
        ├───nix-fast-build: package 'nix-fast-build-0.1.0'
        └───qutebrowser_nightly: package 'python3.11-qutebrowser-unstable-2024-03-24-93b8438'
```

## References

- https://github.com/nix-community/neovim-nightly-overlay/tree/master