### PR TITLE
chore(pkgs): update qutebrowser -> 3d86d78

### DIFF
--- a/pkgs/qutebrowser/metadata.json
+++ b/pkgs/qutebrowser/metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-2023-03-27-0b22011",
-  "rev": "0b220117e2c26dd3ca7639a7bda78a44c8959fbf",
-  "hash": "sha256-rY4squvrK8wJMCg8u3KafKBksHLte/5RyaO3B96cX7s="
+  "version": "unstable-2023-03-27-3d86d78",
+  "rev": "3d86d7876abddea68fd04bd72ce3a7f8c9f297ad",
+  "hash": "sha256-fK8jbFatR90XeM6nSoN0zJalC1PY0YTdXHN4x7h/WRs="
 }


### PR DESCRIPTION
## Results

```console
⯁ pilots git:(qutebrowser-bump) ✗ ❯❯❯ just build-push qutebrowser_nightly
warning: Git tree '/home/kev/Workspace/personal/pilots' is dirty
Finished at 10:25:17 after 0s
Pushing 1 paths (551 are already present) using zstd to cache nixospilots ⏳

✓ /nix/store/19l4wm1a8yalr9pi3rw4bmj2m8d69fc5-python3.11-qutebrowser-unstable-2023-03-27-3d86d78 (9.34 MiB)

All done.
```